### PR TITLE
[RFC] Add support for streaming joins using Esqueleto's experimental API

### DIFF
--- a/persistent-pagination.cabal
+++ b/persistent-pagination.cabal
@@ -33,7 +33,7 @@ library
   build-depends:
       base              >= 4.11     && < 5
     , conduit           >= 1.2.8    && < 1.4
-    , esqueleto         
+    , esqueleto         >= 3.5
     , foldl                            < 1.5.0
     , microlens                        < 0.5
     , mtl                              < 3

--- a/src/Database/Persist/Pagination/Types.hs
+++ b/src/Database/Persist/Pagination/Types.hs
@@ -5,7 +5,6 @@
 module Database.Persist.Pagination.Types where
 
 import Control.Applicative (Alternative(..))
-import           Database.Persist.Sql (Entity)
 
 -- | The amount of records in a 'Page' of results.
 --

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,9 +1,6 @@
-resolver: nightly-2020-11-28
+resolver: nightly-2021-06-01
 
 packages:
 - .
 
 extra-deps:
-- persistent-2.11.0.0
-- persistent-sqlite-2.11.0.0
-- persistent-template-2.9.1.0


### PR DESCRIPTION
Related issue: bitemyapp/esqueleto#267

At the moment, the library can only paginate over entities - but the Esqueleto experimental API could be leveraged to paginate over all kinds of `SELECT` queries. This PR demonstrates a PoC set of changes to allow for paginating over joins, as demonstrated in the added test.

I don't think these changes are merge-ready - documentation is needed, and the orphan instance in Pagination.hs needs to be dealt with, either by suppressing the warning or upstreaming it.